### PR TITLE
Add basic restaurant swiper with results view

### DIFF
--- a/flamed/app/page.js
+++ b/flamed/app/page.js
@@ -1,103 +1,90 @@
-import Image from "next/image";
+'use client';
+
+import { useState } from 'react';
+import { useSwipeable } from 'react-swipeable';
+import Image from 'next/image';
+import restaurants from '../tempRestaurants.json';
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.js
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [index, setIndex] = useState(0);
+  const [liked, setLiked] = useState([]);
+  const [runnerUps, setRunnerUps] = useState([]);
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+  const handleSwipe = (dir) => {
+    const restaurant = restaurants[index];
+    if (dir === 'right') {
+      setLiked([...liked, { ...restaurant, match: 100 }]);
+    } else if (dir === 'left') {
+      const match = Math.floor(Math.random() * 40) + 60; // 60-99
+      setRunnerUps([...runnerUps, { ...restaurant, match }]);
+    }
+    setIndex(index + 1);
+  };
+
+  const handlers = useSwipeable({
+    onSwipedLeft: () => handleSwipe('left'),
+    onSwipedRight: () => handleSwipe('right'),
+    preventScrollOnSwipe: true,
+    trackMouse: true,
+  });
+
+  if (index >= restaurants.length) {
+    return <Results liked={liked} runners={runnerUps} />;
+  }
+
+  const restaurant = restaurants[index];
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4 p-4">
+      <div
+        {...handlers}
+        className="w-80 h-[420px] bg-white rounded-xl shadow-xl overflow-hidden"
+      >
+        <Image
+          src={restaurant.image}
+          alt={restaurant.name}
+          width={320}
+          height={256}
+          className="w-full h-64 object-cover"
+        />
+        <div className="p-4">
+          <h2 className="text-xl font-semibold">{restaurant.name}</h2>
+          <p className="text-sm text-gray-500">Swipe right to like, left to skip.</p>
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+      </div>
+    </div>
+  );
+}
+
+function Results({ liked, runners }) {
+  return (
+    <div className="p-6 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Results</h1>
+      {liked.length === 0 ? (
+        <p className="mb-8">No matches selected.</p>
+      ) : (
+        <ul className="space-y-3 mb-8">
+          {liked.map((r) => (
+            <li key={r.id} className="border p-4 rounded">
+              <div className="font-semibold">{r.name}</div>
+              <div className="text-sm text-gray-600">{r.match}% match</div>
+            </li>
+          ))}
+        </ul>
+      )}
+      {runners.length > 0 && (
+        <>
+          <h2 className="text-xl font-semibold mb-3">Runner Ups</h2>
+          <ul className="space-y-3">
+            {runners.map((r) => (
+              <li key={r.id} className="border p-4 rounded">
+                <div className="font-semibold">{r.name}</div>
+                <div className="text-sm text-gray-600">{r.match}% match</div>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
     </div>
   );
 }

--- a/flamed/next.config.mjs
+++ b/flamed/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/flamed/package-lock.json
+++ b/flamed/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.5.2",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "react-swipeable": "^7.0.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -5037,6 +5038,14 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/flamed/package.json
+++ b/flamed/package.json
@@ -9,15 +9,16 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "next": "15.5.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.5.2"
+    "react-swipeable": "^7.0.2"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4"
   }
 }

--- a/flamed/tempRestaurants.json
+++ b/flamed/tempRestaurants.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": 1,
+    "name": "Burger Bliss",
+    "image": "https://images.unsplash.com/photo-1550547660-d9450f859349?auto=format&fit=crop&w=800&q=80"
+  },
+  {
+    "id": 2,
+    "name": "Sushi Central",
+    "image": "https://images.unsplash.com/photo-1546069901-ba9599a7e63c?auto=format&fit=crop&w=800&q=80"
+  },
+  {
+    "id": 3,
+    "name": "Pasta Paradise",
+    "image": "https://images.unsplash.com/photo-1525755662778-989d0524087e?auto=format&fit=crop&w=800&q=80"
+  }
+]


### PR DESCRIPTION
## Summary
- add `react-swipeable` and sample `tempRestaurants.json` for restaurant cards
- implement swipe interface that tracks liked restaurants and displays runner ups with match percentages
- allow remote Unsplash images in Next.js config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c00bc35aa08326bb16f7255fb49a29